### PR TITLE
Make pcal recognise the start day

### DIFF
--- a/bin/pcal
+++ b/bin/pcal
@@ -9,14 +9,18 @@ my @months = qw(January February March April May June July August
 
 my $mon = shift || (localtime)[4] + 1;
 my $yr  = shift || (localtime)[5] + 1900;
+my $sd  = shift;
+$sd = 1 unless defined $sd;
 
-my @month = calendar($mon, $yr);
-
+my @month = calendar($mon, $yr, $sd);
 my $mon_name = $months[$mon - 1];
 my $pad = int((20 - length("$mon_name $yr")) / 2);
-
 print "\n", ' ' x $pad, "$months[$mon - 1] $yr\n";
-print "Mo Tu We Th Fr Sa Su\n";
+
+my @days = qw(Su Mo Tu We Th Fr Sa);
+push @days, splice @days, 0, $sd;
+print "@days\n";
+
 foreach (@month) {
   print map { $_ ? sprintf "%2d ", $_ : '   ' } @$_;
   print "\n";

--- a/lib/Calendar/Simple.pm
+++ b/lib/Calendar/Simple.pm
@@ -232,11 +232,16 @@ A simple C<cal> replacement would therefore look like this:
 
   my $mon = shift || (localtime)[4] + 1;
   my $yr  = shift || (localtime)[5] + 1900;
+  my $sd  = shift;
+  $ds = 1 unless defined $sd;
 
-  my @month = calendar($mon, $yr);
-
+  my @month = calendar($mon, $yr, $sd);
   print "\n$months[$mon -1] $yr\n\n";
-  print "Su Mo Tu We Th Fr Sa\n";
+
+  my @days = qw(Su Mo Tu We Th Fr Sa);
+  push @days, splice @days, 0, $sd;
+  print "@days\n";
+
   foreach (@month) {
     print map { $_ ? sprintf "%2d ", $_ : '   ' } @$_;
     print "\n";


### PR DESCRIPTION
The default behaviour of the Unix utility "cal" is to start the week on the day that corresponds to the LC_TIME locale. Under en_GB, it's Monday, under en_US, it's Sunday (and under cs_CZ, it's Pondělí, which corresponds to Monday). Adding the third argument to pcal makes it possible to emulate at least both the English approaches.

The expected behaviour is the following commands should succeed:

  pcal 7 2023 1 | diff -wB - <(LC_ALL=en_GB.utf8 cal)
  pcal 7 2023 0 | diff -wB - <(LC_ALL=en_US.utf8 cal)